### PR TITLE
Add JSON-LD context for signature

### DIFF
--- a/lds-ecdsa-secp256k1-recovery2020-0.0.jsonld
+++ b/lds-ecdsa-secp256k1-recovery2020-0.0.jsonld
@@ -4,8 +4,52 @@
     "id": "@id",
     "type": "@type",
     "esrs2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#",
-    "EcdsaSecp256k1RecoverySignature2020": "esrs2020:EcdsaSecp256k1RecoverySignature2020",
     "EcdsaSecp256k1RecoveryMethod2020": "esrs2020:EcdsaSecp256k1RecoveryMethod2020",
+    "EcdsaSecp256k1RecoverySignature2020": {
+      "@id": "esrs2020:EcdsaSecp256k1RecoverySignature2020",
+      "@context": {
+        "@protected": true,
+
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "https://w3id.org/security#proofValue",
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
     "publicKeyJwk": {
       "@id": "esrs2020:publicKeyJwk",
       "@type": "@json"


### PR DESCRIPTION
When using `EcdsaSecp256k1RecoverySignature2020`, I found additional JSON-LD context to be needed for signing and verifying proofs, in order for properties such as `proofPurpose` to be expanded.

In the [Credentials base context](https://w3c.github.io/vc-data-model/#base-context), context for these properties is defined within the context of the proof types like `EcdsaSecp256k1Signature2019`. In a new proof/signature type, it seems they must be defined again, until there is a new version of the credentials based context that includes the needed properties at the top level. In this PR I reuse the context definitions proof types from [JsonWebSignature2020](https://github.com/w3c-ccg/lds-jws2020). This appears the same as in the Credentials base context but without using compact URIs for `sec:` and `xsd:`.