### PR TITLE
Regenerate VC proofs with proof type

### DIFF
--- a/docs/verifiableCredential.json
+++ b/docs/verifiableCredential.json
@@ -30,24 +30,24 @@
   "proof": [
     {
       "type": "EcdsaSecp256k1RecoverySignature2020",
-      "created": "2020-04-11T21:07:05Z",
+      "created": "2021-11-16T22:28:28Z",
       "verificationMethod": "did:example:123#vm-1",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AU0rTaqs7AdpgipHdsosKqSZqh-3tajf2HQaRnZzQStP-vIVMYPps2lqWp5lCDVz07LQt6QQQaEWC1ALw7RWMwA"
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..1QW7BWzMMHZNCF1-Asv3ot05ewi_7syYLuyi4LzzhcIEDGjphuizLkB-14rgnlKK1vlfqhnglchZyvrCGfSTwQE"
     },
     {
       "type": "EcdsaSecp256k1RecoverySignature2020",
-      "created": "2020-04-11T21:07:06Z",
+      "created": "2021-11-16T22:28:28Z",
       "verificationMethod": "did:example:123#vm-2",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ri0hJffnyWUJ1Q41AI2IxS49rH1XEEpx-k0A6HsaQMV1DYwBL9cA5osI10rQmo9dD7iORlH3eEyFFGIJNiFnOgA"
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..U3SFhgj1G12FlWFDddkFdHZ8ktuVwGyOmhYDc2MccFgK9CtnN_9gsVPvNp-CV4X3vHWAUttgp1DUOt0ilRmiCgA"
     },
     {
       "type": "EcdsaSecp256k1RecoverySignature2020",
-      "created": "2020-04-11T21:07:06Z",
+      "created": "2021-11-16T22:28:28Z",
       "verificationMethod": "did:example:123#vm-3",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pp9eiLCMfN4EfSB3cbl3UxJ4TtgUaTfByDaaB6IZbXsnvIy5AUIFjbgaiFNtq9-3f8mP7foD_HXpjrdWZfzlwAE"
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wt1hzqcSx654YaqdCx-6bp6_bkzMbjZc9-071-SRsJsQfUvG_U9ZBWUoCvEtv68Kas10AIvFU6siKw8XZi7knwE"
     }
   ]
 }

--- a/src/__tests__/EcdsaSecp256k1RecoverySignature2020.spec.js
+++ b/src/__tests__/EcdsaSecp256k1RecoverySignature2020.spec.js
@@ -17,6 +17,17 @@ describe("EcdsaSecp256k1RecoverySignature2020", () => {
         key: vm1,
       });
 
+      const canonizeProof = suite.canonizeProof
+      suite.canonizeProof = async function(proof, opts) {
+        proof['@context'] = [
+          'https://w3id.org/security/v2',
+          {
+            "EcdsaSecp256k1RecoverySignature2020": "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#EcdsaSecp256k1RecoverySignature2020"
+          }
+        ];
+        return await canonizeProof.call(this, proof, opts)
+      }
+
       describe("jsigs", () => {
         it("should work as valid signature suite for signing and verifying a document", async () => {
           // We need to do that because jsigs.sign modifies the credential... no bueno


### PR DESCRIPTION
Fix #20. Add a term definition for the proof type while canonicalizing the proof object. Regenerate the proof objects in the example verifiable credential using the updated proof canonicalization.

Verified independently in https://github.com/spruceid/ssi/commit/71279f64c19b47e58ab00e1a675a1911fdd16cf6

Has anyone been depending on the previous `verifiableCredential.json`, such that perhaps this should be noted in the specification as erratum or alternative mode?