### PR TITLE
Improve testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        cache: 'npm'
+    - run: npm install
+    - run: npm test

--- a/docs/unlockedDID.json
+++ b/docs/unlockedDID.json
@@ -92,31 +92,31 @@
   "proof": [
     {
       "type": "EcdsaSecp256k1RecoverySignature2020",
-      "created": "2020-04-11T21:04:54Z",
+      "created": "2021-12-17T22:55:07Z",
       "verificationMethod": "did:example:123#vm-1",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..FA2gQFudZLU4ZOi1f_T2YX5g_dB-KNVcvo19Vhu74t9XpDblDyt1X5-98H7ipe8ypWerxJojeMjnnoHfJ-A4lwA"
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..5VDDwjztlg0NZFEV9BcYC75nA0-ejorerkL8JnSkdi1cVa5cE-Rzz4IPGbiYFgxhwdaDk-y9qg0mMR8--1n_jwE"
     },
     {
       "type": "EcdsaSecp256k1RecoverySignature2020",
-      "created": "2020-04-11T21:04:54Z",
+      "created": "2021-12-17T22:55:07Z",
       "verificationMethod": "did:example:123#vm-2",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..jDnnvCPbA4_AT4MuWrfrdMMzGDtfymh1dQeCpsPKbFMLa0QPOCFS2PKG8YeTGrOmRBif9QYJoxleq0VBPmn9owA"
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..75PnJNBnL21kivslsttIf3sGBP9egwa7WUvP5D3lx1gXVcN4WMEmB2L3PowMtz3Oa770anEfvdCGcyzQboOXYAE"
     },
     {
       "type": "EcdsaSecp256k1RecoverySignature2020",
-      "created": "2020-04-11T21:04:54Z",
+      "created": "2021-12-17T22:55:07Z",
       "verificationMethod": "did:example:123#vm-3",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Q4jeDY1AYhT8i7U4IOJEoTR9KSAlhvg-Od9YroJDLNwNPlj2zSi7U4BDgJR7Or4jmZPRCYZqTGKDK4Dhv2YSMwE"
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9vz6SaITRvdqbkd_lM7yhJRnHqlGMpa6rKGHnoheIfAku8WLCQC9TJqZou1uu5367sxpfIcbXMCxR1Vuuvm-kQE"
     },
     {
       "type": "EcdsaSecp256k1RecoverySignature2020",
-      "created": "2021-11-19T00:45:45Z",
+      "created": "2021-12-17T22:55:08Z",
       "verificationMethod": "did:example:123#vm-4",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..NBzPQ52Jz4-h7X7wCjKTtpdLU_3kz-zeGRLu6m_LoUg5zieFhna78Iu-bhC3lTD6hILqWDFMUH4rRLaVhBlLkQE"
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..s_QsDI0c-ubQAbb_Ntgs8-aJGSWAQocHfIenjzIF-9NXgV5f8GXC-9OSU3TvNAY81kQxQbRQ4wlIae_xvTf9MAE"
     }
   ]
 }

--- a/docs/verifiableCredential.json
+++ b/docs/verifiableCredential.json
@@ -48,6 +48,13 @@
       "verificationMethod": "did:example:123#vm-3",
       "proofPurpose": "assertionMethod",
       "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wt1hzqcSx654YaqdCx-6bp6_bkzMbjZc9-071-SRsJsQfUvG_U9ZBWUoCvEtv68Kas10AIvFU6siKw8XZi7knwE"
+    },
+    {
+      "type": "EcdsaSecp256k1RecoverySignature2020",
+      "created": "2021-12-17T22:36:55Z",
+      "verificationMethod": "did:example:123#vm-4",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fWzq2GBZQBPPyZZfbDCVYz3TI0s0RivTuNakTDyJaAN77i3esHOvzXPSZsy45_zbW3ANSdck_d1bauA94CdQ3AE"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.js",
   "scripts": {
     "test": "jest",
+    "regenerate-test-vectors": "REGENERATE_TEST_VECTORS=1 jest",
     "coverage": "jest --coverage",
     "docs": "jsdoc -c ./jsdoc.json"
   },


### PR DESCRIPTION
This should make it easier to modify the tests and test vectors while making sure they still work.

- Add GitHub Actions file to run tests.
- Verify signed document and verifiable credential in tests.
- Add a regenerate command (`npm run regenerate-test-vectors`) for regenerating the signed test vector files.
- Regenerate signed document proofs (for changes in #21 and #23).
- Add fourth proof to verifiable credential (that should have been added in #23).

Related: #5