### PR TITLE
Fix ReferenceError in EcdsaSecp256k1RecoveryMethod2020

### DIFF
--- a/src/EcdsaSecp256k1RecoveryMethod2020.js
+++ b/src/EcdsaSecp256k1RecoveryMethod2020.js
@@ -1,3 +1,4 @@
+'use strict';
 const base64url = require("base64url");
 const ES256KR = require("./ES256K-R");
 
@@ -170,7 +171,7 @@ function joseSignerFactory(vm) {
  * @returns {{verify: Function}} An async verifier specific
  * to the key passed in.
  */
-joseVerifierFactory = (vm) => {
+const joseVerifierFactory = (vm) => {
   if (
     vm.publicKeyJwk === undefined &&
     vm.publicKeyHex === undefined &&


### PR DESCRIPTION
When dependending on this library via [`@veramo/credential-ld`](https://www.npmjs.com/package/@veramo/credential-ld), I saw a runtime ReferenceError in my browser js console.

This should fix it. 