### PR TITLE
Use main branch instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
- [x] Update CI to build from main (this PR)
- [ ] Update Pages to build from main (I could do this)
- [ ] Update repo to use main as default branch (Someone with privileges would need to do this)